### PR TITLE
Assume 2000s if possible

### DIFF
--- a/flexyear.gemspec
+++ b/flexyear.gemspec
@@ -20,5 +20,6 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
-  spec.add_development_dependency "rspec"
+  spec.add_development_dependency "rspec", "~> 3.5"
+  spec.add_development_dependency "rspec-its", "~> 1.2"
 end

--- a/lib/flexyear.rb
+++ b/lib/flexyear.rb
@@ -40,7 +40,7 @@ class FlexYear
   private
 
   def centuryize(year, base_year=nil)
-    base = "19" # 19th century
+    base = default_base_year(year)
     if base_year
       base = (base_year/100).to_s
     end
@@ -51,6 +51,15 @@ class FlexYear
       "#{base}#{year}"
     else
       year
+    end
+  end
+
+  def default_base_year(year)
+    current_year = Date.today.year.to_s
+    if year.to_i < current_year[-2..-1].to_i
+      "20" # 21st century
+    else
+      "19" # 20th century
     end
   end
 
@@ -66,7 +75,7 @@ class FlexYear
       elsif @year_string =~ starts_with_word_regex
         @base_year = centuryize($1).to_i
       else
-        @base_year = @year_string.gsub(/\D+/,'').to_i
+        @base_year = centuryize(@year_string.gsub(/\D+/,'')).to_i
       end
 
       if @base_year > 9999

--- a/lib/flexyear/version.rb
+++ b/lib/flexyear/version.rb
@@ -1,3 +1,3 @@
 class FlexYear
-  VERSION = "1.0.1"
+  VERSION = "2.0.0"
 end

--- a/spec/flexyear_spec.rb
+++ b/spec/flexyear_spec.rb
@@ -1,7 +1,12 @@
+require "rspec"
 require "rspec/its"
 require 'flexyear'
 
 describe FlexYear do
+  before do
+    allow(Date).to receive(:today) { Date.parse("2016-11-07") }
+  end
+
   [FlexYear, FlexYear::Historical].each do |flexyear_class|
     context "given a blank string" do
       subject { flexyear_class.new("") }
@@ -109,7 +114,7 @@ describe FlexYear do
     end
 
     context "given a range" do
-      ["2003-4", "2003-04"].each do |range|
+      ["2003-4", "2003-04", "03-04"].each do |range|
         subject { flexyear_class.new(range) }
         its(:year_low) { should eq(2003) }
         its(:year_high) { should eq(2004) }
@@ -189,6 +194,19 @@ describe FlexYear do
         its(:year_high) { should eq(1974) }
       end
 
+      context 'given 2 character fields' do
+        context "from previous century" do
+          subject { flexyear_class.new("73") }
+          its(:year_low) { should eq(1973) }
+          its(:year_high) { should eq(1973) }
+        end
+
+        context "from current century" do
+          subject { flexyear_class.new("06") }
+          its(:year_low) { should eq(2006) }
+          its(:year_high) { should eq(2006) }
+        end
+      end
     end
 
     context "given 12345 (five digit year)" do

--- a/spec/flexyear_spec.rb
+++ b/spec/flexyear_spec.rb
@@ -1,3 +1,4 @@
+require "rspec/its"
 require 'flexyear'
 
 describe FlexYear do


### PR DESCRIPTION
This pull makes two changes.

1. It assumes that two digit ranges are for the current century if the given year has occurred in this century (i.e. 03-04 becomes 2003-2004 instead of 1903-1904).
2. It adds the century to two digit years.

I think this is more the expected behavior, but it is breaking so I bumped the version to 2.0.0.