### PR TITLE
Strip input string

### DIFF
--- a/lib/flexyear.rb
+++ b/lib/flexyear.rb
@@ -26,7 +26,7 @@ class FlexYear
   attr_reader :year_low, :year_high
 
   def initialize(year_string)
-    @year_string = year_string.to_s
+    @year_string = year_string.to_s.strip
 
     @low, @high = RangeParser.parse(@year_string)
 

--- a/spec/flexyear_spec.rb
+++ b/spec/flexyear_spec.rb
@@ -38,6 +38,12 @@ describe FlexYear do
       its(:year_high) { should eq(1979) }
     end
 
+    context "given 1979 (with a space)" do
+      subject { flexyear_class.new("1979 ") }
+      its(:year_low) { should eq(1979) }
+      its(:year_high) { should eq(1979) }
+    end
+
     context 'given 197*' do
       subject { flexyear_class.new('197*') }
       its(:year_low) { should eq(1970) }


### PR DESCRIPTION
cc @kylecrum (not sure who else has worked on this)

Had a bug where somebody put it "2001 " and it never got its year min/max and wasn't showing in filters.